### PR TITLE
cleanup and remove creator address from token data

### DIFF
--- a/subscription-nfts/contracts/SubscriptionNFT.sol
+++ b/subscription-nfts/contracts/SubscriptionNFT.sol
@@ -9,11 +9,10 @@ contract SubscriptionNFT is ERC721 {
 
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
-    Counters.Counter private _SubscriptionTemplateIds;
+    Counters.Counter private _subscriptionTemplateIds;
 
     struct TokenData {
         uint256 subscriptionTemplateId;
-        address creatorAddress;
         string accessTier;
         uint256 expirationTime;
     }
@@ -48,7 +47,6 @@ contract SubscriptionNFT is ERC721 {
         SubscriptionOption memory selectedSubscriptionOption = _subscriptionTemplates[subscriptionTemplateId].subscriptionOptions[subscriptionOptionSelectionIndex];
 
         _tokenDatas[newTokenId].subscriptionTemplateId = subscriptionTemplateId;
-        _tokenDatas[newTokenId].creatorAddress = _subscriptionTemplates[subscriptionTemplateId].creatorAddress;
         _tokenDatas[newTokenId].accessTier = selectedSubscriptionOption.accessTier;
         _tokenDatas[newTokenId].expirationTime = block.timestamp + selectedSubscriptionOption.term;
 


### PR DESCRIPTION
remove creator address from token data since we can write a function to look it up from subscription templates using subscription template ids